### PR TITLE
Use one deployment path: deploy main to Workers target

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to Cloudflare Pages
+name: Deploy to Cloudflare Workers
 
 on:
   push:
@@ -26,8 +26,8 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Deploy to Cloudflare Pages
-        run: npx wrangler@latest pages deploy dist --project-name=krakenwatch --branch=main
+      - name: Deploy to Cloudflare Workers
+        run: npx wrangler@latest deploy --config wrangler.workers.toml
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,0 +1,5 @@
+export default {
+  fetch(request, env) {
+    return env.ASSETS.fetch(request);
+  },
+};

--- a/wrangler.workers.toml
+++ b/wrangler.workers.toml
@@ -1,0 +1,7 @@
+name = "wispy-sun-811e"
+main = "./src/worker.js"
+compatibility_date = "2026-04-17"
+
+[assets]
+directory = "./dist"
+not_found_handling = "single-page-application"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- switch GitHub Actions deploy workflow from Cloudflare Pages to Cloudflare Workers
- add a dedicated Workers Wrangler config (`wrangler.workers.toml`) targeting `wispy-sun-811e`
- add a minimal worker entrypoint (`src/worker.js`) that serves built static assets via `env.ASSETS`
- keep SPA deep-link behavior by setting `not_found_handling = "single-page-application"`

## Why
`krakenwatch.com` is effectively tied to the Workers deployment path. Deploying to Pages introduced a second deployment surface and caused live-site confusion. This change makes CI publish to the single, correct target.

## Validation
- `npm run lint` ✅
- `npm run build` ✅
- `npx wrangler@latest deploy --config wrangler.workers.toml --dry-run` ✅ (assets discovered and deploy plan generated)

## Follow-up cleanup
- after this merges and is confirmed live, remove old Pages deployment resources/config to keep one source of truth
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

