### PR TITLE
Fix Workers deep-link handling for SPA routes

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -1,5 +1,14 @@
 export default {
-  fetch(request, env) {
-    return env.ASSETS.fetch(request);
+  async fetch(request, env) {
+    const response = await env.ASSETS.fetch(request);
+    if (response.status !== 404) {
+      return response;
+    }
+
+    // Serve index for unknown routes so SPA deep links resolve.
+    const url = new URL(request.url);
+    url.pathname = '/index.html';
+    const indexRequest = new Request(url.toString(), request);
+    return env.ASSETS.fetch(indexRequest);
   },
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update `src/worker.js` to handle SPA deep links safely with explicit `/index.html` fallback logic
- first serve requested asset/path via `env.ASSETS.fetch(request)`
- if response is 404, rewrite request path to `/index.html` and return that response

## Why
After switching to Workers deployment, direct requests to routes like `/ink` and `/alpha-briefs` returned Cloudflare 1101/500 errors due to fallback behavior in the current worker implementation.

## Validation
- `npm run lint` ✅
- `npm run build` ✅
- `npx wrangler@latest deploy --config wrangler.workers.toml --dry-run` ✅

This should restore route-level availability for deep links on production.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

