### PR TITLE
Fix 1101 errors on Workers deep-link routes

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -1,14 +1,18 @@
 export default {
   async fetch(request, env) {
-    const response = await env.ASSETS.fetch(request);
-    if (response.status !== 404) {
-      return response;
+    const url = new URL(request.url);
+    const isHtmlRoute =
+      request.method === 'GET' &&
+      url.pathname !== '/' &&
+      !url.pathname.startsWith('/assets/') &&
+      !url.pathname.includes('.');
+
+    // For SPA routes like /ink and /alpha-briefs, serve index directly.
+    if (isHtmlRoute) {
+      url.pathname = '/index.html';
+      return env.ASSETS.fetch(new Request(url.toString(), request));
     }
 
-    // Serve index for unknown routes so SPA deep links resolve.
-    const url = new URL(request.url);
-    url.pathname = '/index.html';
-    const indexRequest = new Request(url.toString(), request);
-    return env.ASSETS.fetch(indexRequest);
+    return env.ASSETS.fetch(request);
   },
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update `src/worker.js` route handling to rewrite SPA routes to `/index.html` before asset fetch
- keep direct asset requests (`/assets/*` and paths containing file extensions) as passthrough
- preserve root path `/` behavior as normal asset request

## Why
After merging the previous Workers migration, direct route requests such as `/ink`, `/payward`, and `/alpha-briefs` returned Cloudflare 1101 runtime errors. This patch avoids fallback recursion by handling SPA route rewrites deterministically.

## Validation
- `npm run lint` ✅
- `npm run build` ✅
- `npx wrangler@latest deploy --config wrangler.workers.toml --dry-run` ✅

Expected result after merge/deploy: deep links return 200 and load the React app correctly.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

