### PR TITLE
Fix Workers 1101 by explicitly binding static assets

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -1,18 +1,6 @@
 export default {
   async fetch(request, env) {
-    const url = new URL(request.url);
-    const isHtmlRoute =
-      request.method === 'GET' &&
-      url.pathname !== '/' &&
-      !url.pathname.startsWith('/assets/') &&
-      !url.pathname.includes('.');
-
-    // For SPA routes like /ink and /alpha-briefs, serve index directly.
-    if (isHtmlRoute) {
-      url.pathname = '/index.html';
-      return env.ASSETS.fetch(new Request(url.toString(), request));
-    }
-
+    // Let Cloudflare static assets routing handle SPA fallback.
     return env.ASSETS.fetch(request);
   },
 };

--- a/wrangler.workers.toml
+++ b/wrangler.workers.toml
@@ -4,4 +4,5 @@ compatibility_date = "2026-04-17"
 
 [assets]
 directory = "./dist"
+binding = "ASSETS"
 not_found_handling = "single-page-application"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add explicit static assets binding in `wrangler.workers.toml`:
  - `binding = "ASSETS"`
- simplify `src/worker.js` to directly call `env.ASSETS.fetch(request)` and rely on Cloudflare's configured `not_found_handling = "single-page-application"`

## Why
Deep-link routes (`/ink`, `/payward`, `/alpha-briefs`) were returning Cloudflare 1101 errors after Workers migration. The Worker runtime did not have a guaranteed assets binding configured, causing route handling failures.

## Validation
- `npm run lint` ✅
- `npm run build` ✅
- `npx wrangler@latest deploy --config wrangler.workers.toml --dry-run` ✅
- dry-run now reports binding presence:
  - `env.ASSETS  Assets`

Expected outcome after merge/deploy: deep links return `200` and render SPA routes correctly.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

