### PR TITLE
Set Workers as canonical and deploy known-good site snapshot

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to Cloudflare Pages
+name: Deploy to Cloudflare Workers
 
 on:
   push:
@@ -26,8 +26,8 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Deploy to Cloudflare Pages
-        run: npx wrangler@latest pages deploy dist --project-name=krakenwatch --commit-dirty=true
+      - name: Deploy to Cloudflare Workers
+        run: npx wrangler@latest deploy --config wrangler.workers.toml
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -1,6 +1,5 @@
 const qp = 'hsl(28 40% 14%)';
 const b5 = 'hsl(350 55% 32%)';
-const ut = 'hsl(30 20% 38%)';
 
 export default function About() {
   return (

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,0 +1,6 @@
+export default {
+  async fetch(request, env) {
+    // Serve static assets and let Cloudflare handle SPA fallback policy.
+    return env.ASSETS.fetch(request);
+  },
+};

--- a/wrangler.workers.toml
+++ b/wrangler.workers.toml
@@ -1,0 +1,8 @@
+name = "wispy-sun-811e"
+main = "./src/worker.js"
+compatibility_date = "2026-04-17"
+
+[assets]
+directory = "./dist"
+binding = "ASSETS"
+not_found_handling = "single-page-application"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- keep the app code at the known-good snapshot baseline (same bundle family as the stable site you approved)
- switch CI deployment target to Cloudflare Workers (`wispy-sun-811e`)
- add Workers config + asset binding:
  - `wrangler.workers.toml`
  - `src/worker.js`
- preserve SPA route behavior with static-assets config:
  - `not_found_handling = "single-page-application"`

## Why
You confirmed the desired production topology is to keep custom-domain wiring on Workers and put the good site into that target. This PR does exactly that.

## Validation
- `npm run lint` ✅
- `npm run build` ✅
- build output matches known-good bundle family:
  - `dist/assets/index-C8JYzMg0.js`
  - `dist/assets/index-BYmsAbz-.css`
- `npx wrangler@latest deploy --config wrangler.workers.toml --dry-run` ✅
  - confirms `env.ASSETS` binding is present

## Post-merge
After merge/deploy, verify `krakenwatch.com` serves the same hashes above and visual parity with your approved baseline.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

