### PR TITLE
Fix Workers deploy by excluding Pages _redirects asset

### DIFF
--- a/public/.assetsignore
+++ b/public/.assetsignore
@@ -1,0 +1,1 @@
+_redirects


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Hotfix

## Summary
- add `public/.assetsignore` with `_redirects`

## Why
Workers deploy is currently failing when uploading the known-good site snapshot because `public/_redirects` (a Cloudflare Pages rule file) is being included in Workers static assets and rejected with:
- `Invalid _redirects configuration`
- `Infinite loop detected` (code 10021)

This file should not be uploaded in Workers mode.

## Validation
- `npm run build` ✅
- `npx wrangler@latest deploy --config wrangler.workers.toml --dry-run` ✅
- known-good bundle hashes still produced:
  - `dist/assets/index-C8JYzMg0.js`
  - `dist/assets/index-BYmsAbz-.css`

After merge, the workers deploy should succeed and allow production to move to the known-good snapshot.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

