### PR TITLE
Hotfix: remove Pages _redirects before Workers deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Remove Pages-only redirect rules from Workers assets
+        run: rm -f dist/_redirects
+
       - name: Deploy to Cloudflare Workers
         run: npx wrangler@latest deploy --config wrangler.workers.toml
         env:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add an explicit CI step to remove `dist/_redirects` before Workers deploy

## Why
Workers deployments are currently failing due to Pages redirect rules being present in uploaded assets:
- `Invalid _redirects configuration`
- `Infinite loop detected` (code 10021)

Even with `.assetsignore`, `_redirects` can still exist in the build output and block deploys. This hotfix enforces a reliable guardrail in CI.

## Validation
- local CI simulation:
  - `npm run build`
  - `rm -f dist/_redirects`
  - `wrangler deploy --config wrangler.workers.toml --dry-run` ✅
- known-good bundle still produced:
  - `index-C8JYzMg0.js`
  - `index-BYmsAbz-.css`

After merge, Workers deploy should complete and production can switch to the known-good snapshot.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

