### PR TITLE
Emergency restore: pin Workers to known-good deployment 1d2a3088

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -1,6 +1,8 @@
 export default {
   async fetch(request, env) {
-    // Serve static assets and let Cloudflare handle SPA fallback policy.
-    return env.ASSETS.fetch(request);
+    // Emergency pin: proxy to known-good deployment while source parity is resolved.
+    const url = new URL(request.url);
+    url.hostname = '1d2a3088.krakenwatch.pages.dev';
+    return fetch(new Request(url.toString(), request));
   },
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Emergency fix

## Summary
- update `src/worker.js` to proxy all traffic to the known-good deployment:
  - `https://1d2a3088.krakenwatch.pages.dev`

## Why
User-confirmed production is still rendering the incorrect variant. The fastest deterministic restore is to pin Workers/custom-domain traffic to the exact deployment that is confirmed good.

## Validation
- `npm run build` ✅
- `wrangler deploy --config wrangler.workers.toml --dry-run` ✅

## Important follow-up
This is an emergency stabilization step. After incident is closed, we should replace this pin with native local asset serving from the exact same source snapshot to remove cross-origin dependency.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

