### PR TITLE
Urgent hotfix: unblock deploy and keep known-good pin

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
           test -f src/worker.js
           # Pages redirect rules must never be uploaded in Workers mode.
           test -f public/.assetsignore
-          rg '^_redirects$' public/.assetsignore
+          grep -x '_redirects' public/.assetsignore
 
       - name: Remove Pages-only redirect rules from Workers assets
         run: rm -f dist/_redirects

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,5 +1,5 @@
 export default {
-  async fetch(request, env) {
+  async fetch(request) {
     // Emergency pin: proxy to known-good deployment while source parity is resolved.
     const url = new URL(request.url);
     url.hostname = '1d2a3088.krakenwatch.pages.dev';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Urgent hotfix

## Summary
- replace non-portable `rg` usage in deploy invariant step with `grep -x`
- fix worker lint issue (`env` unused) while preserving emergency known-good proxy behavior

## Why
PR #14 merged but deployment failed before deploy step due to missing `rg` in GitHub runner (`exit code 127`). This prevented the emergency restore from going live.

## Validation
- `npm run lint` ✅
- `npm run build` ✅
- known-good build bundle still produced:
  - `index-C8JYzMg0.js`
  - `index-BYmsAbz-.css`

After merge, workflow should run to completion and apply the emergency known-good restore pin.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

