### PR TITLE
Emergency fix: force worker proxy for all routes

### DIFF
--- a/wrangler.workers.toml
+++ b/wrangler.workers.toml
@@ -6,3 +6,4 @@ compatibility_date = "2026-04-17"
 directory = "./dist"
 binding = "ASSETS"
 not_found_handling = "single-page-application"
+run_worker_first = true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Emergency fix

## Summary
- set `run_worker_first = true` in `wrangler.workers.toml`

## Why
Current behavior is mixed: some requests are served by local Worker assets and others by the emergency proxy target, causing inconsistent site output. Enabling `run_worker_first = true` ensures the Worker script handles all requests first, so the emergency proxy to `1d2a3088.krakenwatch.pages.dev` is applied uniformly.

## Validation
- `npm run lint` ✅
- `npm run build` ✅
- `wrangler deploy --config wrangler.workers.toml --dry-run` ✅

After merge/deploy, production should fully match the known-good deployment across `/`, `/ink`, `/payward`, `/alpha-briefs`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

