### PR TITLE
Emergency rollback: restore known-good pinned deployment behavior

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,19 +23,17 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build pinned production artifact bundle
-        run: |
-          npm run build
+      - name: Build
+        run: npm run build
 
       - name: Validate deployment configuration invariants
         run: |
           # Workers is the canonical production target.
           test -f wrangler.workers.toml
           test -f src/worker.js
-          # Dist must exist and contain one JS/CSS bundle pair.
-          test -f dist/index.html
-          ls dist/assets/index-*.js | head -n1
-          ls dist/assets/index-*.css | head -n1
+          # Pages redirect rules must never be uploaded in Workers mode.
+          test -f public/.assetsignore
+          grep -x '_redirects' public/.assetsignore
 
       - name: Remove Pages-only redirect rules from Workers assets
         run: rm -f dist/_redirects

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,6 +1,8 @@
 export default {
-  async fetch(request, env) {
-    // Serve the pinned known-good static artifact bundle directly from Workers assets.
-    return env.ASSETS.fetch(request);
+  async fetch(request) {
+    // Emergency pin: proxy to known-good deployment while source parity is resolved.
+    const url = new URL(request.url);
+    url.hostname = '1d2a3088.krakenwatch.pages.dev';
+    return fetch(new Request(url.toString(), request));
   },
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Emergency rollback

## Summary
- revert `src/worker.js` to emergency known-good proxy behavior:
  - proxy requests to `1d2a3088.krakenwatch.pages.dev`
- revert deploy workflow to the previously working configuration used before the recent breakage

## Why
The latest merge reintroduced an incorrect production variant. Priority is immediate restoration of the known-good live site.

## Validation
- `npm run lint` ✅
- `npm run build` ✅

After merge/deploy, production should match the previously approved good version again.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

