### PR TITLE
Hotfix: force Worker-first proxy so live site matches known-good version

### DIFF
--- a/wrangler.workers.toml
+++ b/wrangler.workers.toml
@@ -6,3 +6,4 @@ compatibility_date = "2026-04-17"
 directory = "./dist"
 binding = "ASSETS"
 not_found_handling = "single-page-application"
+run_worker_first = true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
This hotfix restores `run_worker_first = true` in `wrangler.workers.toml`.

## Why
`main` currently has the emergency proxy in `src/worker.js` (to `1d2a3088.krakenwatch.pages.dev`), but without `run_worker_first` Cloudflare may serve static assets before the Worker runs. That causes `krakenwatch.com` to keep showing the wrong artifact set.

## Change
- `wrangler.workers.toml`
  - Added:
    - `run_worker_first = true`

## Validation
- Confirmed current `main` includes proxy worker logic.
- Confirmed current production and workers domain were still serving non-proxied assets before this fix.
- This setting restores the behavior that ensures all requests are handled by the Worker proxy path first.

## Risk
Low. Single-line config restoration, specifically scoped to request handling order in Workers assets mode.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

