### PR TITLE
Incident hardening: block proxy regressions and smoke-check live routes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,11 +4,17 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+
+concurrency:
+  group: krakenwatch-production-deploy
+  cancel-in-progress: false
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     name: Build & Deploy
+    timeout-minutes: 20
 
     steps:
       - name: Checkout
@@ -35,6 +41,13 @@ jobs:
           test -f public/.assetsignore
           grep -x '_redirects' public/.assetsignore
 
+      - name: Validate emergency proxy mode invariants
+        run: |
+          # Prevent the exact outage mode where the Worker proxy exists
+          # but is bypassed due to worker-first handling being disabled.
+          grep -Fx "run_worker_first = true" wrangler.workers.toml
+          grep -F "url.hostname = '1d2a3088.krakenwatch.pages.dev';" src/worker.js
+
       - name: Remove Pages-only redirect rules from Workers assets
         run: rm -f dist/_redirects
 
@@ -43,3 +56,66 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Smoke-check production routes against known-good baseline
+        run: |
+          set -euo pipefail
+          BASELINE_HOST="https://1d2a3088.krakenwatch.pages.dev"
+          PROD_HOST="https://krakenwatch.com"
+          WORKER_HOST="https://wispy-sun-811e.krakenwatch.workers.dev"
+
+          extract_signature() {
+            local url="$1"
+            local html
+            html="$(curl -fsSL "$url")"
+            local title js css
+            title="$(printf '%s' "$html" | grep -oE '<title>[^<]+</title>' | head -n1)"
+            js="$(printf '%s' "$html" | grep -oE '/assets/index-[^"]+\.js' | head -n1)"
+            css="$(printf '%s' "$html" | grep -oE '/assets/index-[^"]+\.css' | head -n1)"
+
+            test -n "$title"
+            test -n "$js"
+            test -n "$css"
+            printf '%s|%s|%s\n' "$title" "$js" "$css"
+          }
+
+          check_route() {
+            local route="$1"
+            local prod_url="${PROD_HOST}${route}"
+            local baseline_url="${BASELINE_HOST}${route}"
+            local worker_url="${WORKER_HOST}${route}"
+            local prod_status baseline_status worker_status prod_sig baseline_sig worker_sig
+
+            for attempt in 1 2 3 4 5; do
+              prod_status="$(curl -fsSL -o /dev/null -w '%{http_code}' "$prod_url")"
+              baseline_status="$(curl -fsSL -o /dev/null -w '%{http_code}' "$baseline_url")"
+              worker_status="$(curl -fsSL -o /dev/null -w '%{http_code}' "$worker_url")"
+              test "$prod_status" = "200"
+              test "$baseline_status" = "200"
+              test "$worker_status" = "200"
+
+              prod_sig="$(extract_signature "$prod_url")"
+              baseline_sig="$(extract_signature "$baseline_url")"
+              worker_sig="$(extract_signature "$worker_url")"
+
+              if [ "$prod_sig" = "$baseline_sig" ] && [ "$worker_sig" = "$baseline_sig" ]; then
+                return 0
+              fi
+
+              if [ "$attempt" -lt 5 ]; then
+                sleep 6
+              fi
+            done
+
+            echo "Route mismatch on ${route}"
+            echo "  production: ${prod_sig}"
+            echo "  worker:     ${worker_sig}"
+            echo "  baseline:   ${baseline_sig}"
+            exit 1
+          }
+
+          check_route /
+          check_route /ink
+          check_route /payward
+          check_route /alpha-briefs
+          check_route /about

--- a/DEPLOYMENT_RUNBOOK.md
+++ b/DEPLOYMENT_RUNBOOK.md
@@ -15,20 +15,35 @@ This project now uses a **single production deployment path**:
 1. Do not route `krakenwatch.com` to a second production project.
 2. Do not upload Pages `_redirects` into Workers assets.
 3. Keep only one production-capable domain binding active.
+4. While emergency proxy mode is active, both must stay true:
+   - `src/worker.js` proxies to `1d2a3088.krakenwatch.pages.dev`
+   - `wrangler.workers.toml` contains `run_worker_first = true`
 
 ## Deploy checks
 
-After each merge:
+After each merge (automated in CI and also safe to run manually):
 
 1. Verify workflow success (`Deploy to Cloudflare Workers`).
-2. Verify hashes on:
+2. Verify hashes/signatures on:
    - `https://krakenwatch.com/`
    - `https://wispy-sun-811e.krakenwatch.workers.dev/`
-3. Verify routes return `200`:
+   - Baseline comparison target: `https://1d2a3088.krakenwatch.pages.dev/`
+3. Verify routes return `200` and signatures match baseline:
    - `/`
    - `/ink`
    - `/payward`
    - `/alpha-briefs`
+   - `/about`
+
+## Incident-prevention guardrails in CI
+
+The deploy workflow now hard-fails if either condition regresses:
+
+- Proxy host pin removed from `src/worker.js`
+- `run_worker_first = true` missing in `wrangler.workers.toml`
+
+After deployment, CI also compares production + worker route signatures to the
+known-good baseline route-by-route (`/`, `/ink`, `/payward`, `/alpha-briefs`, `/about`).
 
 ## Cloudflare cleanup target
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why
Production regressions occurred because deploys could succeed while the live domain served the wrong artifact path (Worker proxy bypassed). This PR adds hard CI guardrails so that failure mode cannot pass silently.

## What changed
### 1) Deploy workflow hardening (`.github/workflows/deploy.yml`)
- Added `workflow_dispatch` trigger for manual verification runs.
- Added deploy `concurrency` group to avoid overlapping production deploys.
- Added job timeout (`timeout-minutes: 20`).
- Added **emergency proxy invariants** step that hard-fails when:
  - `run_worker_first = true` is missing from `wrangler.workers.toml`.
  - proxy host pin line is missing from `src/worker.js`.
- Added **post-deploy smoke checks** that compare signatures for:
  - `https://krakenwatch.com`
  - `https://wispy-sun-811e.krakenwatch.workers.dev`
  - against baseline `https://1d2a3088.krakenwatch.pages.dev`
- Smoke checks run across `/`, `/ink`, `/payward`, `/alpha-briefs`, `/about`, require HTTP 200, and verify title/js/css signature parity with retry window.

### 2) Runbook updates (`DEPLOYMENT_RUNBOOK.md`)
- Documented emergency proxy mode invariants.
- Documented automated CI guardrails and baseline route signature checks.

## Validation performed
- Executed the smoke-check logic against current live endpoints.
- Verified signature parity and 200 status on `/`, `/ink`, `/payward`, `/alpha-briefs`, `/about`.

## Impact
This makes the deploy pipeline fail fast if proxy mode drifts and prevents “green deploy, wrong live site” incidents from reaching production unnoticed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

