### PR TITLE
Add ongoing PR live preview mode with isolated Workers URLs

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,130 @@
+name: PR Live Preview (Workers)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+concurrency:
+  group: krakenwatch-pr-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    name: Deploy PR Preview
+    permissions:
+      pull-requests: write
+      contents: read
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Remove Pages-only redirect rules from preview assets
+        run: rm -f dist/_redirects
+
+      - name: Deploy PR preview Worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          PREVIEW_NAME="krakenwatch-pr-${PR_NUMBER}"
+          DEPLOY_LOG="$(mktemp)"
+
+          npx wrangler@latest deploy ./src/preview-worker.js \
+            --name "$PREVIEW_NAME" \
+            --compatibility-date "$(date +%Y-%m-%d)" \
+            --assets ./dist | tee "$DEPLOY_LOG"
+
+          PREVIEW_URL="$(grep -Eo 'https://[a-zA-Z0-9-]+\.[a-zA-Z0-9-]+\.workers\.dev' "$DEPLOY_LOG" | head -n1)"
+          test -n "$PREVIEW_URL"
+          printf 'PREVIEW_URL=%s\n' "$PREVIEW_URL" >> "$GITHUB_ENV"
+          printf 'PREVIEW_NAME=%s\n' "$PREVIEW_NAME" >> "$GITHUB_ENV"
+
+      - name: Smoke-check preview routes
+        run: |
+          set -euo pipefail
+          test -n "${PREVIEW_URL:-}"
+          for route in / /ink /payward /alpha-briefs /about; do
+            code="$(curl -fsSL -o /dev/null -w '%{http_code}' "${PREVIEW_URL}${route}")"
+            test "$code" = "200"
+          done
+
+      - name: Comment preview URL on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- krakenwatch-pr-preview -->';
+            const body = `${marker}
+            🔎 **PR Live Preview Ready**
+
+            - URL: ${process.env.PREVIEW_URL}
+            - Worker: \`${process.env.PREVIEW_NAME}\`
+            - Smoke checks: passed (\`/\`, \`/ink\`, \`/payward\`, \`/alpha-briefs\`, \`/about\`)
+
+            This preview is isolated from production and updates on each commit to this PR.`;
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
+
+  cleanup-preview:
+    if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    name: Cleanup PR Preview
+    timeout-minutes: 10
+
+    steps:
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Delete preview Worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          PREVIEW_NAME="krakenwatch-pr-${PR_NUMBER}"
+          npx wrangler@latest delete "$PREVIEW_NAME" --force || true

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -63,8 +63,23 @@ jobs:
           set -euo pipefail
           test -n "${PREVIEW_URL:-}"
           for route in / /ink /payward /alpha-briefs /about; do
-            code="$(curl -fsSL -o /dev/null -w '%{http_code}' "${PREVIEW_URL}${route}")"
-            test "$code" = "200"
+            ok=0
+            for attempt in 1 2 3 4 5 6; do
+              code="$(curl -sSL -o /dev/null -w '%{http_code}' "${PREVIEW_URL}${route}")"
+              if [ "$code" = "200" ]; then
+                ok=1
+                break
+              fi
+              if [ "$attempt" -lt 6 ]; then
+                sleep 5
+              fi
+            done
+
+            if [ "$ok" -ne 1 ]; then
+              echo "Preview route did not become ready: ${route}"
+              echo "Last status code: ${code}"
+              exit 1
+            fi
           done
 
       - name: Comment preview URL on PR

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -48,6 +48,7 @@ jobs:
           DEPLOY_LOG="$(mktemp)"
 
           npx wrangler@latest deploy ./src/preview-worker.js \
+            --config wrangler.workers.toml \
             --name "$PREVIEW_NAME" \
             --compatibility-date "$(date +%Y-%m-%d)" \
             --assets ./dist | tee "$DEPLOY_LOG"
@@ -127,4 +128,4 @@ jobs:
         run: |
           set -euo pipefail
           PREVIEW_NAME="krakenwatch-pr-${PR_NUMBER}"
-          npx wrangler@latest delete "$PREVIEW_NAME" --force || true
+          npx wrangler@latest delete "$PREVIEW_NAME" --config wrangler.workers.toml --force || true

--- a/README.md
+++ b/README.md
@@ -39,6 +39,30 @@ If the site looks wrong:
 3. Confirm route responses (`/`, `/ink`, `/payward`, `/alpha-briefs`) are HTTP `200`.
 4. Purge Cloudflare cache only **after** confirming deploy target/domain routing are correct.
 
+## PR live preview workflow
+
+Each pull request now gets an isolated preview URL via the workflow:
+
+- `.github/workflows/pr-preview.yml`
+- GitHub Actions name: `PR Live Preview (Workers)`
+
+How it works:
+
+1. On PR open/sync/reopen, CI builds and deploys a Worker named `krakenwatch-pr-<PR_NUMBER>`.
+2. It smoke-checks `200` responses on:
+   - `/`
+   - `/ink`
+   - `/payward`
+   - `/alpha-briefs`
+   - `/about`
+3. It comments (and updates) a single preview URL comment on the PR.
+4. On PR close, it deletes the preview Worker automatically.
+
+Notes:
+
+- Preview deploys are isolated from production.
+- Production deploy remains `main` -> `Deploy to Cloudflare Workers`.
+
 ## Local development
 
 Install deps and run the app:

--- a/src/preview-worker.js
+++ b/src/preview-worker.js
@@ -1,0 +1,13 @@
+export default {
+  async fetch(request, env) {
+    const assetResponse = await env.ASSETS.fetch(request);
+    if (assetResponse.status !== 404) {
+      return assetResponse;
+    }
+
+    // SPA fallback for deep links in preview environments.
+    const fallbackUrl = new URL(request.url);
+    fallbackUrl.pathname = '/index.html';
+    return env.ASSETS.fetch(new Request(fallbackUrl.toString(), request));
+  },
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds an ongoing **live preview mode** for pull requests so every PR gets a safe, isolated URL for visual review before merge.

## What this adds
### 1) New workflow: `.github/workflows/pr-preview.yml`
- Triggered on PR events (`opened`, `synchronize`, `reopened`, `closed`).
- Builds the app and deploys an isolated Worker preview per PR:
  - Worker name format: `krakenwatch-pr-<PR_NUMBER>`
- Serves built static assets from `dist`.
- Runs smoke checks on preview routes:
  - `/`, `/ink`, `/payward`, `/alpha-briefs`, `/about`
- Posts/updates one PR comment with the preview URL.
- Cleans up preview Worker automatically when PR is closed.

### 2) Preview worker entrypoint: `src/preview-worker.js`
- Serves static assets via `env.ASSETS.fetch`.
- Adds SPA fallback to `/index.html` for deep links in preview environments.

### 3) Docs update: `README.md`
- Added a `PR live preview workflow` section explaining behavior and usage.

## Fixes included after initial failed checks
### A) Force Workers config (not Pages)
The first run failed because Wrangler interpreted the repo as a Pages project. The workflow now explicitly uses:
- Deploy: `--config wrangler.workers.toml`
- Cleanup: `--config wrangler.workers.toml`

### B) Handle preview propagation delay
A later run failed because immediate route checks hit transient 404 right after deployment. Smoke checks now retry route readiness before failing.

## Why
This gives a repeatable, easy preview process for ongoing work and avoids touching production while evaluating design/content changes.

## Safety
- Preview deploys are isolated from production.
- Existing production workflow/guardrails remain unchanged (`main` deploy).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

