### PR TITLE
Add automated daily data refresh cron workflow

### DIFF
--- a/.github/workflows/daily-data-refresh.yml
+++ b/.github/workflows/daily-data-refresh.yml
@@ -1,0 +1,53 @@
+name: Daily Data Refresh
+
+on:
+  schedule:
+    # Run daily at 14:15 UTC.
+    - cron: '15 14 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: krakenwatch-daily-data-refresh
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    name: Refresh site-data.json
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Refresh site data
+        run: npm run refresh:data
+
+      - name: Commit and push refreshed data
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- public/site-data.json; then
+            echo "No data changes detected."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add public/site-data.json
+          git commit -m "chore(data): daily refresh site-data"
+          git push origin HEAD:main

--- a/README.md
+++ b/README.md
@@ -79,3 +79,26 @@ Build and lint:
 npm run build
 npm run lint
 ```
+
+Refresh data snapshot locally:
+
+```bash
+npm run refresh:data
+```
+
+## Daily data refresh automation
+
+The project includes a scheduled GitHub Actions workflow:
+
+- `.github/workflows/daily-data-refresh.yml`
+- Workflow name: `Daily Data Refresh`
+- Schedule: daily at `14:15 UTC`
+
+It refreshes `public/site-data.json` from:
+
+- DeFiLlama (Ink TVL + protocol count)
+- Polymarket (`kraken-ipo-in-2025`)
+- Kalshi (`KXIPO-26-KRAKEN`)
+- Hiive, Forge, Nasdaq Private Market, Notice (best-effort secondary price sources)
+
+The workflow commits updated `public/site-data.json` back to `main` when values change.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "refresh:data": "node scripts/refresh-site-data.mjs"
   },
   "dependencies": {
     "react": "^19.2.4",

--- a/public/site-data.json
+++ b/public/site-data.json
@@ -1,23 +1,23 @@
 {
-  "updated_at": "2026-04-16T14:04:19Z",
-  "updated_display": "April 16, 2026",
+  "updated_at": "2026-04-17T20:20:20.501Z",
+  "updated_display": "April 17, 2026",
   "ink": {
-    "tvl_millions": 476.7,
+    "tvl_millions": 489.2,
     "protocol_count": 26
   },
   "ipo": {
-    "polymarket_pct": 72.0,
-    "kalshi_pct": 73.5,
-    "avg_pct": 72.8
+    "polymarket_pct": 75,
+    "kalshi_pct": 67.5,
+    "avg_pct": 67.8
   },
   "secondary_market": {
-    "hiive_pps": 31.88,
-    "forge_pps": 32.49,
+    "hiive_pps": 33.29,
+    "forge_pps": 29.7,
     "npm_pps": 37.69,
     "notice_pps": 31.36,
-    "avg_pps": 33.36,
+    "avg_pps": 31.99,
     "volume_30d_est_m": 13.5,
-    "volume_note": "Est. 30D vol. across all venues \u00b7 based on Hiive H50 activity",
-    "updated": "April 16, 2026"
+    "volume_note": "Est. 30D vol. across all venues · based on Hiive H50 activity",
+    "updated": "April 17, 2026"
   }
 }

--- a/scripts/refresh-site-data.mjs
+++ b/scripts/refresh-site-data.mjs
@@ -1,0 +1,467 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { setTimeout as delay } from 'node:timers/promises';
+
+const SITE_DATA_PATH = new URL('../public/site-data.json', import.meta.url);
+
+const SECONDARY_BASE_WEIGHTS = {
+  hiive_pps: 0.4,
+  forge_pps: 0.3,
+  npm_pps: 0.2,
+  notice_pps: 0.1,
+};
+
+const MAX_OUTLIER_DEVIATION = 0.3;
+
+function parseNumeric(input) {
+  if (input == null) {
+    return null;
+  }
+  if (typeof input === 'number' && Number.isFinite(input)) {
+    return input;
+  }
+  if (typeof input === 'string') {
+    const cleaned = input.replace(/[$,%\s,]/g, '');
+    const value = Number.parseFloat(cleaned);
+    return Number.isFinite(value) ? value : null;
+  }
+  return null;
+}
+
+function round(value, decimals = 1) {
+  if (!Number.isFinite(value)) {
+    return null;
+  }
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+}
+
+function safeJsonParse(value, fallback = null) {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return fallback;
+  }
+}
+
+function weightedAverage(entries) {
+  const valid = entries.filter(
+    (entry) => Number.isFinite(entry.value) && Number.isFinite(entry.weight) && entry.weight > 0,
+  );
+
+  if (!valid.length) {
+    return null;
+  }
+
+  const totalWeight = valid.reduce((sum, entry) => sum + entry.weight, 0);
+  if (totalWeight <= 0) {
+    return null;
+  }
+
+  return valid.reduce((sum, entry) => sum + entry.value * entry.weight, 0) / totalWeight;
+}
+
+function median(values) {
+  if (!values.length) {
+    return null;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+function parseDateFromText(value) {
+  if (!value) {
+    return null;
+  }
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+function freshnessMultiplier(sourceDate, now) {
+  if (!sourceDate) {
+    return 0.35;
+  }
+  const ageMs = Math.max(0, now.getTime() - sourceDate.getTime());
+  const ageDays = ageMs / (1000 * 60 * 60 * 24);
+  // exponential-like linear cap:
+  // <=2d -> ~1.0, 14d -> ~0.6, >=45d -> 0.2
+  if (ageDays <= 2) {
+    return 1;
+  }
+  if (ageDays >= 45) {
+    return 0.2;
+  }
+  return 1 - ((ageDays - 2) / (45 - 2)) * 0.8;
+}
+
+async function fetchText(url, options = {}) {
+  const response = await fetch(url, options);
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} at ${url}`);
+  }
+  return response.text();
+}
+
+async function fetchJson(url, options = {}) {
+  const response = await fetch(url, options);
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} at ${url}`);
+  }
+  return response.json();
+}
+
+async function withRetries(name, fn, retries = 3) {
+  let lastError = null;
+  for (let attempt = 1; attempt <= retries; attempt += 1) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      if (attempt < retries) {
+        await delay(1000 * attempt);
+      }
+    }
+  }
+  throw new Error(`${name} failed after ${retries} attempts: ${lastError?.message ?? 'unknown error'}`);
+}
+
+async function runOptional(name, fn) {
+  try {
+    return await fn();
+  } catch (error) {
+    console.warn(`${name} unavailable: ${error.message}`);
+    return null;
+  }
+}
+
+async function getDefiLlamaData() {
+  const [chains, protocols] = await Promise.all([
+    withRetries('DeFiLlama chains', () => fetchJson('https://api.llama.fi/v2/chains')),
+    withRetries('DeFiLlama protocols', () => fetchJson('https://api.llama.fi/protocols')),
+  ]);
+
+  const inkChain = chains.find((chain) => String(chain.name || '').toLowerCase() === 'ink');
+  if (!inkChain || !Number.isFinite(inkChain.tvl)) {
+    throw new Error('Ink chain TVL not found in DeFiLlama response');
+  }
+
+  const protocolCount = protocols.filter(
+    (protocol) => Array.isArray(protocol.chains) && protocol.chains.some((c) => String(c).toLowerCase() === 'ink'),
+  ).length;
+
+  return {
+    tvl_millions: round(inkChain.tvl / 1_000_000, 1),
+    protocol_count: protocolCount,
+  };
+}
+
+function extractPolymarketMarket(eventPayload) {
+  if (!Array.isArray(eventPayload) || !eventPayload.length) {
+    return null;
+  }
+  const event = eventPayload[0];
+  if (!Array.isArray(event.markets)) {
+    return null;
+  }
+
+  const active2026 = event.markets.find(
+    (market) =>
+      market.active === true &&
+      market.closed === false &&
+      typeof market.question === 'string' &&
+      market.question.toLowerCase().includes('by december 31, 2026'),
+  );
+
+  return active2026 ?? event.markets.find((market) => market.active === true && market.closed === false) ?? null;
+}
+
+function parsePolymarketProbability(market) {
+  if (!market) {
+    return null;
+  }
+  const yesBid = parseNumeric(market.bestBid);
+  const yesAsk = parseNumeric(market.bestAsk);
+  if (yesBid != null && yesAsk != null && yesBid >= 0 && yesAsk <= 1.1) {
+    return (yesBid + yesAsk) / 2;
+  }
+
+  const prices = safeJsonParse(market.outcomePrices, null);
+  if (Array.isArray(prices) && prices.length) {
+    const yes = parseNumeric(prices[0]);
+    if (yes != null) {
+      return yes;
+    }
+  }
+
+  return parseNumeric(market.lastTradePrice);
+}
+
+async function getPolymarketData() {
+  const events = await withRetries('Polymarket event', () =>
+    fetchJson('https://gamma-api.polymarket.com/events?slug=kraken-ipo-in-2025'),
+  );
+  const market = extractPolymarketMarket(events);
+  if (!market) {
+    throw new Error('Polymarket active market not found');
+  }
+
+  const probability = parsePolymarketProbability(market);
+  if (probability == null) {
+    throw new Error('Polymarket probability missing');
+  }
+
+  const spread = (() => {
+    const bid = parseNumeric(market.bestBid);
+    const ask = parseNumeric(market.bestAsk);
+    if (bid == null || ask == null) {
+      return 0.08;
+    }
+    return Math.max(0.01, ask - bid);
+  })();
+
+  const volume = parseNumeric(market.volume24hr ?? market.volume1wk ?? market.volumeNum ?? market.volume);
+  const openInterest = parseNumeric(market.openInterest);
+  const liquidityWeight = Math.max(1, (volume ?? 0) / 1000 + (openInterest ?? 0) / 10000);
+  const spreadPenalty = 1 / Math.max(0.01, spread * 100);
+
+  return {
+    pct: round(probability * 100, 1),
+    weight: Math.max(0.15, liquidityWeight * spreadPenalty),
+  };
+}
+
+async function getKalshiData() {
+  const payload = await withRetries('Kalshi market', () =>
+    fetchJson('https://api.elections.kalshi.com/trade-api/v2/markets/KXIPO-26-KRAKEN'),
+  );
+  const market = payload?.market;
+  if (!market) {
+    throw new Error('Kalshi market payload missing');
+  }
+
+  const yesBid = parseNumeric(market.yes_bid_dollars);
+  const yesAsk = parseNumeric(market.yes_ask_dollars);
+  const lastPrice = parseNumeric(market.last_price_dollars);
+
+  let probability = null;
+  if (yesBid != null && yesAsk != null) {
+    probability = (yesBid + yesAsk) / 2;
+  } else {
+    probability = lastPrice;
+  }
+
+  if (probability == null) {
+    throw new Error('Kalshi probability missing');
+  }
+
+  const spread = yesBid != null && yesAsk != null ? Math.max(0.01, yesAsk - yesBid) : 0.08;
+  const volume = parseNumeric(market.volume_24h_fp ?? market.volume_fp);
+  const openInterest = parseNumeric(market.open_interest_fp);
+  const liquidityWeight = Math.max(1, (volume ?? 0) / 200 + (openInterest ?? 0) / 5000);
+  const spreadPenalty = 1 / Math.max(0.01, spread * 100);
+
+  return {
+    pct: round(probability * 100, 1),
+    weight: Math.max(0.15, liquidityWeight * spreadPenalty),
+  };
+}
+
+function extractFirstCurrency(html, contextRegex = null) {
+  if (!html) {
+    return null;
+  }
+
+  let target = html;
+  if (contextRegex) {
+    const ctx = target.match(contextRegex);
+    if (ctx?.[0]) {
+      target = ctx[0];
+    }
+  }
+
+  const direct = target.match(/\$([0-9]{1,4}(?:\.[0-9]{1,2})?)/);
+  if (!direct) {
+    return null;
+  }
+  return parseNumeric(direct[1]);
+}
+
+async function getHiivePrice() {
+  const html = await withRetries('Hiive page', () =>
+    fetchText('https://www.hiive.com/securities/kraken-stock', {
+      headers: { 'user-agent': 'Mozilla/5.0 (KrakenWatch refresh bot)' },
+    }),
+  );
+  return extractFirstCurrency(html, /Kraken Stock[\s\S]{0,800}/i);
+}
+
+async function getNpmPriceAndDate() {
+  const html = await withRetries('Nasdaq Private Market page', () =>
+    fetchText('https://www.nasdaqprivatemarket.com/company/kraken/', {
+      headers: { 'user-agent': 'Mozilla/5.0 (KrakenWatch refresh bot)' },
+    }),
+  );
+  const pps = extractFirstCurrency(html, /Kraken Stock Price Per Share[\s\S]{0,1200}/i);
+  const updatedMatch = html.match(/Updated\s+([A-Za-z]{3,9},?\s+\d{4})/i);
+  const sourceDate = updatedMatch ? parseDateFromText(updatedMatch[1]) : null;
+  return { pps, sourceDate };
+}
+
+async function getForgePriceAndDate() {
+  const html = await withRetries('Forge page', () =>
+    fetchText('https://forgeglobal.com/kraken_stock/', {
+      headers: { 'user-agent': 'Mozilla/5.0 (KrakenWatch refresh bot)' },
+    }),
+  );
+
+  const priceMatch = html.match(/Kraken Forge Price is \$([0-9]+(?:\.[0-9]{1,2})?)/i);
+  const dateMatch = html.match(/as of ([0-9]{2}\/[0-9]{2}\/[0-9]{4})/i);
+
+  return {
+    pps: priceMatch ? parseNumeric(priceMatch[1]) : null,
+    sourceDate: dateMatch ? parseDateFromText(dateMatch[1]) : null,
+  };
+}
+
+async function getNoticePrice() {
+  try {
+    const html = await withRetries(
+      'Notice page',
+      () =>
+        fetchText('https://notice.co/c/kraken', {
+          headers: { 'user-agent': 'Mozilla/5.0 (KrakenWatch refresh bot)' },
+        }),
+      2,
+    );
+    return extractFirstCurrency(html, /Kraken[\s\S]{0,1200}/i);
+  } catch {
+    return null;
+  }
+}
+
+function buildSecondaryMarket(existing, live, now) {
+  const merged = {
+    hiive_pps: live.hiive_pps ?? existing.hiive_pps ?? null,
+    forge_pps: live.forge_pps ?? existing.forge_pps ?? null,
+    npm_pps: live.npm_pps ?? existing.npm_pps ?? null,
+    notice_pps: live.notice_pps ?? existing.notice_pps ?? null,
+    avg_pps: existing.avg_pps ?? null,
+    volume_30d_est_m: existing.volume_30d_est_m ?? null,
+    volume_note: existing.volume_note ?? '',
+    updated: now.toLocaleDateString('en-US', {
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric',
+      timeZone: 'UTC',
+    }),
+  };
+
+  const prices = [
+    { key: 'hiive_pps', value: merged.hiive_pps },
+    { key: 'forge_pps', value: merged.forge_pps },
+    { key: 'npm_pps', value: merged.npm_pps },
+    { key: 'notice_pps', value: merged.notice_pps },
+  ].filter((entry) => Number.isFinite(entry.value));
+
+  if (!prices.length) {
+    return merged;
+  }
+
+  const med = median(prices.map((entry) => entry.value));
+  const filtered = prices.filter((entry) => {
+    if (!Number.isFinite(med) || med <= 0) {
+      return true;
+    }
+    return Math.abs(entry.value - med) / med <= MAX_OUTLIER_DEVIATION;
+  });
+
+  const byKey = Object.fromEntries(filtered.map((entry) => [entry.key, entry.value]));
+
+  const candidates = filtered.map((entry) => {
+    const baseWeight = SECONDARY_BASE_WEIGHTS[entry.key] ?? 0.1;
+    const sourceDate =
+      entry.key === 'forge_pps'
+        ? live.forge_date ?? null
+        : entry.key === 'npm_pps'
+          ? live.npm_date ?? null
+          : now;
+    const weight = baseWeight * freshnessMultiplier(sourceDate, now);
+    return { value: entry.value, weight };
+  });
+
+  const avg = weightedAverage(candidates);
+  if (avg != null) {
+    merged.avg_pps = round(avg, 2);
+  } else if (Number.isFinite(existing.avg_pps)) {
+    merged.avg_pps = existing.avg_pps;
+  }
+
+  // Preserve canonical source fields even if filtered out from averaging.
+  merged.hiive_pps = byKey.hiive_pps ?? merged.hiive_pps;
+  merged.forge_pps = byKey.forge_pps ?? merged.forge_pps;
+  merged.npm_pps = byKey.npm_pps ?? merged.npm_pps;
+  merged.notice_pps = byKey.notice_pps ?? merged.notice_pps;
+
+  return merged;
+}
+
+async function main() {
+  const now = new Date();
+  const existingRaw = await readFile(SITE_DATA_PATH, 'utf8');
+  const existing = safeJsonParse(existingRaw, {});
+
+  const [ink, poly, kalshi, hiive, npm, forge, notice] = await Promise.all([
+    getDefiLlamaData(),
+    getPolymarketData(),
+    getKalshiData(),
+    runOptional('Hiive', getHiivePrice),
+    runOptional('Nasdaq Private Market', getNpmPriceAndDate),
+    runOptional('Forge', getForgePriceAndDate),
+    runOptional('Notice', getNoticePrice),
+  ]);
+
+  const ipoCandidates = [
+    { value: poly.pct, weight: poly.weight },
+    { value: kalshi.pct, weight: kalshi.weight },
+  ];
+
+  const ipoAvg = weightedAverage(ipoCandidates);
+
+  const secondaryMarket = buildSecondaryMarket(
+    existing.secondary_market ?? {},
+    {
+      hiive_pps: hiive,
+      forge_pps: forge?.pps ?? null,
+      npm_pps: npm?.pps ?? null,
+      notice_pps: notice,
+      forge_date: forge?.sourceDate ?? null,
+      npm_date: npm?.sourceDate ?? null,
+    },
+    now,
+  );
+
+  const updated = {
+    updated_at: now.toISOString(),
+    updated_display: now.toLocaleDateString('en-US', {
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric',
+      timeZone: 'UTC',
+    }),
+    ink,
+    ipo: {
+      polymarket_pct: poly.pct,
+      kalshi_pct: kalshi.pct,
+      avg_pct: ipoAvg != null ? round(ipoAvg, 1) : existing.ipo?.avg_pct ?? null,
+    },
+    secondary_market: secondaryMarket,
+  };
+
+  await writeFile(SITE_DATA_PATH, `${JSON.stringify(updated, null, 2)}\n`);
+  console.log('Updated public/site-data.json successfully.');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a scheduled GitHub Actions workflow (`Daily Data Refresh`) that runs every day at 14:15 UTC and can also be run manually
- add a refresh script (`scripts/refresh-site-data.mjs`) that updates `public/site-data.json` from live sources
- add `npm run refresh:data` for local/manual refreshes and document the automation in `README.md`

## Data refresh behavior
- Ink metrics: pulls TVL + protocol count from DeFiLlama
- IPO odds: pulls Polymarket + Kalshi and computes a liquidity/spread-weighted estimate
- Secondary PPS: pulls Hiive, Forge, Nasdaq Private Market, and Notice (best-effort), applies outlier filtering, freshness-weighted averaging, and graceful fallback to prior values when a source is unavailable

## Verification
- `npm run refresh:data`
- `npm run lint`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a179696-b4c7-4a30-b488-3ac5e9b47493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a179696-b4c7-4a30-b488-3ac5e9b47493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

