### PR TITLE
Test-host only: apply Blackbeard to About page body text

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -1,8 +1,30 @@
 export default {
   async fetch(request) {
     // Emergency pin: proxy to known-good deployment while source parity is resolved.
-    const url = new URL(request.url);
-    url.hostname = '1d2a3088.krakenwatch.pages.dev';
-    return fetch(new Request(url.toString(), request));
+    const incomingUrl = new URL(request.url);
+    const proxiedUrl = new URL(request.url);
+    proxiedUrl.hostname = '1d2a3088.krakenwatch.pages.dev';
+
+    const response = await fetch(new Request(proxiedUrl.toString(), request));
+
+    // Preview-only tweak: use Blackbeard for About page body text on workers.dev test host.
+    if (
+      incomingUrl.hostname === 'wispy-sun-811e.krakenwatch.workers.dev' &&
+      incomingUrl.pathname === '/about' &&
+      (response.headers.get('content-type') || '').includes('text/html')
+    ) {
+      const html = await response.text();
+      const patched = html.replace(
+        '</head>',
+        '<style id="about-blackbeard-test-only">main p{font-family:"Blackbeard","Trade Winds",Georgia,serif!important;line-height:1.5;letter-spacing:.01em}</style></head>',
+      );
+      return new Response(patched, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+      });
+    }
+
+    return response;
   },
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Applies Blackbeard font to About page body text **only on the workers.dev test host** for visual review.

## Scope
- File changed: `src/worker.js`
- Behavior:
  - Requests are still proxied to the known-good baseline.
  - For `https://wispy-sun-811e.krakenwatch.workers.dev/about` only, Worker injects a small `<style>` block into HTML response head.
  - Style applied:
    - `main p { font-family: "Blackbeard", "Trade Winds", Georgia, serif !important; ... }`

## Safety
- `krakenwatch.com` is unaffected.
- No custom-domain behavior changes.
- This is host-gated + path-gated + content-type-gated.

## Validation
- `npm run lint` passes.
- `npm run build` passes.

## Purpose
Provide a quick, live visual preview of Blackbeard body text treatment on the About page without changing production behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

