### PR TITLE
Hotfix: satisfy worker invariant check and keep About font test tweak

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -2,10 +2,10 @@ export default {
   async fetch(request) {
     // Emergency pin: proxy to known-good deployment while source parity is resolved.
     const incomingUrl = new URL(request.url);
-    const proxiedUrl = new URL(request.url);
-    proxiedUrl.hostname = '1d2a3088.krakenwatch.pages.dev';
+    const url = new URL(request.url);
+    url.hostname = '1d2a3088.krakenwatch.pages.dev';
 
-    const response = await fetch(new Request(proxiedUrl.toString(), request));
+    const response = await fetch(new Request(url.toString(), request));
 
     // Preview-only tweak: use Blackbeard for About page body text on workers.dev test host.
     if (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes the failed production deploy after PR #27 by restoring the exact worker invariant pattern expected by CI while keeping the About-page Blackbeard test tweak on the workers.dev host.

## Root cause
`Deploy to Cloudflare Workers` failed in `Validate emergency proxy mode invariants`.

The workflow checks for this exact line pattern in `src/worker.js`:
- `url.hostname = '1d2a3088.krakenwatch.pages.dev';`

PR #27 changed variable naming and no longer matched the check string exactly, causing CI failure.

## Change
- Updated `src/worker.js` to use:
  - `const url = new URL(request.url);`
  - `url.hostname = '1d2a3088.krakenwatch.pages.dev';`
- Kept the host-gated About-page style injection logic intact:
  - only on `wispy-sun-811e.krakenwatch.workers.dev`
  - only on `/about`
  - only for `text/html`

## Validation
- `npm run lint` passes
- `npm run build` passes

## Impact
- Unblocks production deploy pipeline.
- Preserves the requested test-host-only Blackbeard About-body preview behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

