### PR TITLE
Fix About Blackbeard preview selector on workers test host

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -10,7 +10,6 @@ export default {
     // Preview-only tweak: use Blackbeard for About page body text on workers.dev test host.
     if (
       incomingUrl.hostname === 'wispy-sun-811e.krakenwatch.workers.dev' &&
-      incomingUrl.pathname === '/about' &&
       (response.headers.get('content-type') || '').includes('text/html')
     ) {
       const html = await response.text();

--- a/src/worker.js
+++ b/src/worker.js
@@ -16,7 +16,7 @@ export default {
       const html = await response.text();
       const patched = html.replace(
         '</head>',
-        '<style id="about-blackbeard-test-only">main p{font-family:"Blackbeard","Trade Winds",Georgia,serif!important;line-height:1.5;letter-spacing:.01em}</style></head>',
+        '<style id="about-blackbeard-test-only">p.text-base, p.text-base.sm\\:text-lg{font-family:"Blackbeard","Trade Winds",Georgia,serif!important;line-height:1.5;letter-spacing:.01em}</style></head>',
       );
       return new Response(patched, {
         status: response.status,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix the preview-only About font injection selector in `src/worker.js`
- apply injection for HTML shell responses on `wispy-sun-811e.krakenwatch.workers.dev` so client-side navigation to About receives the style
- target About copy classes directly: `p.text-base, p.text-base.sm\:text-lg`
- keep canonical proxy invariant unchanged (`url.hostname = '1d2a3088.krakenwatch.pages.dev';`)

## Validation
- `npm run lint`
- `npm run build`

## Root cause
The earlier logic only injected when the incoming path was `/about`. In the current app shell, About is typically reached via client-side tab navigation while the document request remains `/`, so no injection occurred.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

