### PR TITLE
Hotfix worker to serve live site-data from assets

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -1,5 +1,12 @@
 export default {
-  async fetch(request) {
+  async fetch(request, env) {
+    // Keep site-data on the current Worker deployment so daily refresh commits
+    // on main become live without waiting for baseline Pages parity updates.
+    const requestUrl = new URL(request.url);
+    if (requestUrl.pathname === '/site-data.json' && env?.ASSETS) {
+      return env.ASSETS.fetch(request);
+    }
+
     // Emergency pin: proxy to known-good deployment while source parity is resolved.
     const url = new URL(request.url);
     url.hostname = '1d2a3088.krakenwatch.pages.dev';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- route `/site-data.json` to Worker `ASSETS` instead of the emergency baseline proxy host
- keep emergency proxy behavior unchanged for all other routes

## Why
- daily refresh commits update `public/site-data.json` on `main`, but production was still serving stale baseline data through the proxy pin
- this change makes daily refreshed data visible on production immediately after deploy

## Verification
- `npm run lint`
- `npm run build`
- verified worker diff routes only `/site-data.json` to `env.ASSETS.fetch(request)`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a179696-b4c7-4a30-b488-3ac5e9b47493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a179696-b4c7-4a30-b488-3ac5e9b47493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

