### PR TITLE
Fix test-host Blackbeard preview by serving font asset

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -1,7 +1,19 @@
 export default {
-  async fetch(request) {
+  async fetch(request, env) {
     // Emergency pin: proxy to known-good deployment while source parity is resolved.
     const incomingUrl = new URL(request.url);
+
+    // Preview-only asset route: serve Blackbeard from local worker assets so the
+    // test-host About override can load the actual font file instead of HTML fallback.
+    if (
+      incomingUrl.hostname === 'wispy-sun-811e.krakenwatch.workers.dev' &&
+      incomingUrl.pathname === '/fonts/blackbeard.woff' &&
+      env &&
+      env.ASSETS
+    ) {
+      return env.ASSETS.fetch(request);
+    }
+
     const url = new URL(request.url);
     url.hostname = '1d2a3088.krakenwatch.pages.dev';
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update `src/worker.js` fetch signature to accept `env`
- add preview-only route for `wispy-sun-811e.krakenwatch.workers.dev/fonts/blackbeard.woff`
- serve that request from `env.ASSETS` so the font URL returns an actual WOFF file
- keep the existing test-host About text override using `Blackbeard`

## Root cause
The About override correctly referenced `Blackbeard`, but on the test host `/fonts/blackbeard.woff` returned HTML fallback (content-type text/html) from the upstream proxy path, so browsers fell back to `Trade Winds`.

## Validation
- `npm run lint`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

