### PR TITLE
Apply About Blackbeard + left-align override on prod and test hosts

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -9,10 +9,14 @@ export default {
     // Emergency pin: proxy to known-good deployment while source parity is resolved.
     const incomingUrl = new URL(request.url);
 
-    // Preview-only asset route: serve Blackbeard from local worker assets so the
-    // test-host About override can load the actual font file instead of HTML fallback.
+    const isAboutTypographyHost =
+      incomingUrl.hostname === 'wispy-sun-811e.krakenwatch.workers.dev' ||
+      incomingUrl.hostname === 'krakenwatch.com';
+
+    // Host-scoped asset route: serve Blackbeard from local worker assets so the
+    // About override can load the actual font file instead of HTML fallback.
     if (
-      incomingUrl.hostname === 'wispy-sun-811e.krakenwatch.workers.dev' &&
+      isAboutTypographyHost &&
       incomingUrl.pathname === '/fonts/blackbeard.woff' &&
       env &&
       env.ASSETS
@@ -25,9 +29,9 @@ export default {
 
     const response = await fetch(new Request(url.toString(), request));
 
-    // Preview-only tweak: use Blackbeard for About page body text on workers.dev test host.
+    // Host-scoped tweak: use Blackbeard for About page body text.
     if (
-      incomingUrl.hostname === 'wispy-sun-811e.krakenwatch.workers.dev' &&
+      isAboutTypographyHost &&
       (response.headers.get('content-type') || '').includes('text/html')
     ) {
       const html = await response.text();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- extend the host scope for About typography override in `src/worker.js`
- apply the Blackbeard + left-align About paragraph override on both:
  - `krakenwatch.com`
  - `wispy-sun-811e.krakenwatch.workers.dev`
- serve `/fonts/blackbeard.woff` from `env.ASSETS` for both hosts so Blackbeard resolves as a real font file

## Root cause
The override and font asset route were previously scoped only to the workers test host, so production never received the About Blackbeard styling and its `/fonts/blackbeard.woff` path still resolved to HTML fallback.

## Validation
- `npm run lint`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

