### PR TITLE
Update About launch copy to site and X phrasing

### DIFF
--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -12,17 +12,20 @@ export default function About() {
           Ahoy, matey! Welcome t' the <span className="fancy-accent">Watch</span>!
         </h1>
         <p className="text-base sm:text-lg leading-relaxed" style={{ fontFamily: 'var(--font-serif)', color: qp, opacity: 0.85 }}>
-          Kraken Watch launched on April 10, 2026 and lives on our site and on{' '}
+          Kraken Watch set sail in April 2026 to plunder signals, scuttlebutt, and actionable insight from across the vast seas of Kraken, Payward, Ink, and the rising frontier of digital assets beyond.
+        </p>
+        <p className="text-base sm:text-lg leading-relaxed" style={{ fontFamily: 'var(--font-serif)', color: qp, opacity: 0.85 }}>
+          Join the crew on{' '}
           <a href="https://x.com/KrakWatch" target="_blank" rel="noopener noreferrer"
             className="font-semibold underline decoration-dotted underline-offset-2 hover:opacity-70 transition-opacity"
-            style={{ color: b5 }}>X</a>
-          .
+            style={{ color: b5 }}>@krakwatch</a>{' '}
+          on X 🏴‍☠️
         </p>
         <p className="text-base sm:text-lg leading-relaxed" style={{ fontFamily: 'var(--font-serif)', color: qp, opacity: 0.85 }}>
           Created by{' '}
           <a href="https://x.com/salwilliam" target="_blank" rel="noopener noreferrer"
             className="font-semibold underline decoration-dotted underline-offset-2 hover:opacity-70 transition-opacity"
-            style={{ color: b5 }}>@salwilliam</a>.
+            style={{ color: b5 }}>@salwilliam</a>
         </p>
 
         {/* Anchor divider */}

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -12,14 +12,11 @@ export default function About() {
           Ahoy, matey! Welcome t' the <span className="fancy-accent">Watch</span>!
         </h1>
         <p className="text-base sm:text-lg leading-relaxed" style={{ fontFamily: 'var(--font-serif)', color: qp, opacity: 0.85 }}>
-          Kraken Watch first set sail on{' '}
+          Kraken Watch launched on April 10, 2026 and lives on our site and on{' '}
           <a href="https://x.com/KrakWatch" target="_blank" rel="noopener noreferrer"
             className="font-semibold underline decoration-dotted underline-offset-2 hover:opacity-70 transition-opacity"
             style={{ color: b5 }}>X</a>
-          , gathering the signals and scuttlebutt of the Kraken ecosystem into one handy port o' call.
-        </p>
-        <p className="text-base sm:text-lg leading-relaxed" style={{ fontFamily: 'var(--font-serif)', color: qp, opacity: 0.85 }}>
-          On April 10, 2026, we launched our own site — same credo: useful insights and data from across the Kraken, Payward, and Ink universe.
+          .
         </p>
         <p className="text-base sm:text-lg leading-relaxed" style={{ fontFamily: 'var(--font-serif)', color: qp, opacity: 0.85 }}>
           Created by{' '}

--- a/src/worker.js
+++ b/src/worker.js
@@ -37,10 +37,13 @@ export default {
       const html = await response.text();
       const textPatched = html.replace(
         "Kraken Watch first set sail on X, gathering the signals and scuttlebutt of the Kraken ecosystem into one handy port o' call.",
-        'Kraken Watch launched on April 10, 2026 and lives on our site and on X.',
+        'Kraken Watch set sail in April 2026 to plunder signals, scuttlebutt, and actionable insight from across the vast seas of Kraken, Payward, Ink, and the rising frontier of digital assets beyond.',
       ).replace(
         'On April 10, 2026, we launched our own site — same credo: useful insights and data from across the Kraken, Payward, and Ink universe.',
         '',
+      ).replace(
+        /Created by\s*<a href="https:\/\/x\.com\/salwilliam"[^>]*>@salwilliam<\/a>\./,
+        'Join the crew on <a href="https://x.com/KrakWatch" target="_blank" rel="noopener noreferrer" class="font-semibold underline decoration-dotted underline-offset-2 hover:opacity-70 transition-opacity" style="color: hsl(350 55% 32%)">@krakwatch</a> on X 🏴‍☠️</p><p class="text-base sm:text-lg leading-relaxed" style="font-family: var(--font-serif); color: hsl(28 40% 14%); opacity: 0.85">Created by <a href="https://x.com/salwilliam" target="_blank" rel="noopener noreferrer" class="font-semibold underline decoration-dotted underline-offset-2 hover:opacity-70 transition-opacity" style="color: hsl(350 55% 32%)">@salwilliam</a>',
       );
       const patched = textPatched.replace(
         '</head>',

--- a/src/worker.js
+++ b/src/worker.js
@@ -35,7 +35,14 @@ export default {
       (response.headers.get('content-type') || '').includes('text/html')
     ) {
       const html = await response.text();
-      const patched = html.replace(
+      const textPatched = html.replace(
+        "Kraken Watch first set sail on X, gathering the signals and scuttlebutt of the Kraken ecosystem into one handy port o' call.",
+        'Kraken Watch launched on April 10, 2026 and lives on our site and on X.',
+      ).replace(
+        'On April 10, 2026, we launched our own site — same credo: useful insights and data from across the Kraken, Payward, and Ink universe.',
+        '',
+      );
+      const patched = textPatched.replace(
         '</head>',
         '<style id="about-blackbeard-test-only">@font-face{font-family:"Blackbeard";font-style:normal;font-weight:400;font-display:swap;src:url("/fonts/blackbeard.woff") format("woff")}p.text-base, p.text-base.sm\\:text-lg{font-family:"Blackbeard","Trade Winds",Georgia,serif!important;line-height:1.5;letter-spacing:.01em;text-align:left!important}</style></head>',
       );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update About copy to the new sentence:
  - `Kraken Watch set sail in April 2026 to plunder signals, scuttlebutt, and actionable insight from across the vast seas of Kraken, Payward, Ink, and the rising frontier of digital assets beyond.`
- append the requested closing lines while preserving the existing style/layout:
  - `Join the crew on X 🏴‍☠️`
  - `Created by @salwilliam`
- add explicit X profile links in the About body text:
  - `@krakwatch` (links to `https://x.com/KrakWatch`)
  - `@salwilliam` (links to `https://x.com/salwilliam`)
- keep worker-side HTML text patch aligned so proxied host output matches source copy

## Validation
- `npm run lint`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

