### PR TITLE
Apply About copy and link updates on live proxied hosts

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -35,19 +35,9 @@ export default {
       (response.headers.get('content-type') || '').includes('text/html')
     ) {
       const html = await response.text();
-      const textPatched = html.replace(
-        "Kraken Watch first set sail on X, gathering the signals and scuttlebutt of the Kraken ecosystem into one handy port o' call.",
-        'Kraken Watch set sail in April 2026 to plunder signals, scuttlebutt, and actionable insight from across the vast seas of Kraken, Payward, Ink, and the rising frontier of digital assets beyond.',
-      ).replace(
-        'On April 10, 2026, we launched our own site — same credo: useful insights and data from across the Kraken, Payward, and Ink universe.',
-        '',
-      ).replace(
-        /Created by\s*<a href="https:\/\/x\.com\/salwilliam"[^>]*>@salwilliam<\/a>\./,
-        'Join the crew on <a href="https://x.com/KrakWatch" target="_blank" rel="noopener noreferrer" class="font-semibold underline decoration-dotted underline-offset-2 hover:opacity-70 transition-opacity" style="color: hsl(350 55% 32%)">@krakwatch</a> on X 🏴‍☠️</p><p class="text-base sm:text-lg leading-relaxed" style="font-family: var(--font-serif); color: hsl(28 40% 14%); opacity: 0.85">Created by <a href="https://x.com/salwilliam" target="_blank" rel="noopener noreferrer" class="font-semibold underline decoration-dotted underline-offset-2 hover:opacity-70 transition-opacity" style="color: hsl(350 55% 32%)">@salwilliam</a>',
-      );
-      const patched = textPatched.replace(
+      const patched = html.replace(
         '</head>',
-        '<style id="about-blackbeard-test-only">@font-face{font-family:"Blackbeard";font-style:normal;font-weight:400;font-display:swap;src:url("/fonts/blackbeard.woff") format("woff")}p.text-base, p.text-base.sm\\:text-lg{font-family:"Blackbeard","Trade Winds",Georgia,serif!important;line-height:1.5;letter-spacing:.01em;text-align:left!important}</style></head>',
+        '<style id="about-blackbeard-test-only">@font-face{font-family:"Blackbeard";font-style:normal;font-weight:400;font-display:swap;src:url("/fonts/blackbeard.woff") format("woff")}p.text-base, p.text-base.sm\\:text-lg{font-family:"Blackbeard","Trade Winds",Georgia,serif!important;line-height:1.5;letter-spacing:.01em;text-align:left!important}</style><script id="about-copy-live-patch">(function(){const aboutSentence="Kraken Watch set sail in April 2026 to plunder signals, scuttlebutt, and actionable insight from across the vast seas of Kraken, Payward, Ink, and the rising frontier of digital assets beyond.";const linkClass="font-semibold underline decoration-dotted underline-offset-2 hover:opacity-70 transition-opacity";const linkStyle="color: hsl(350 55% 32%)";const joinHtml=\'Join the crew on <a href="https://x.com/KrakWatch" target="_blank" rel="noopener noreferrer" class="\'+linkClass+\'" style="\'+linkStyle+\'">@krakwatch</a> on X 🏴‍☠️\';const createdHtml=\'Created by <a href="https://x.com/salwilliam" target="_blank" rel="noopener noreferrer" class="\'+linkClass+\'" style="\'+linkStyle+\'">@salwilliam</a>\';function patchAbout(){const heading=[...document.querySelectorAll("h1")].find((el)=>el.textContent&&el.textContent.includes("Ahoy, matey!"));if(!heading){return;}const container=heading.parentElement;if(!container){return;}const paragraphs=[...container.querySelectorAll("p.text-base, p.text-base.sm\\\\:text-lg")];if(!paragraphs.length){return;}const cloneFrom=paragraphs[0];const ensureParagraph=(index)=>{if(paragraphs[index]){return paragraphs[index];}const p=document.createElement("p");p.className=cloneFrom.className;const style=cloneFrom.getAttribute("style");if(style){p.setAttribute("style",style);}const anchor=index===1?paragraphs[0]:paragraphs[index-1];anchor.after(p);paragraphs[index]=p;return p;};const aboutP=ensureParagraph(0);aboutP.textContent=aboutSentence;const joinP=ensureParagraph(1);joinP.innerHTML=joinHtml;const createdP=ensureParagraph(2);createdP.innerHTML=createdHtml;}function run(){try{patchAbout();}catch(e){}}if(document.readyState==="loading"){document.addEventListener("DOMContentLoaded",run,{once:true});}run();new MutationObserver(run).observe(document.documentElement,{childList:true,subtree:true});})();</script></head>',
       );
       return new Response(patched, {
         status: response.status,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update `src/worker.js` to apply About copy updates via a host-scoped client-side patch script for proxied HTML
- preserve existing Blackbeard + left-align typography override for About paragraphs
- ensure requested copy appears on both `krakenwatch.com` and `wispy-sun-811e.krakenwatch.workers.dev` despite emergency proxy mode

## What this fixes
The previous string-replace patch depended on exact static HTML text and did not consistently apply once the proxied app rendered content client-side. This patch updates About copy and links in the rendered DOM.

## Resulting About content
- `Kraken Watch set sail in April 2026 to plunder signals, scuttlebutt, and actionable insight from across the vast seas of Kraken, Payward, Ink, and the rising frontier of digital assets beyond.`
- `Join the crew on @krakwatch on X 🏴‍☠️` (linked)
- `Created by @salwilliam` (linked)

## Validation
- `npm run lint`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

