### PR TITLE
Add daily Ink X snapshot monitoring and report workflow

### DIFF
--- a/.github/workflows/daily-x-monitor.yml
+++ b/.github/workflows/daily-x-monitor.yml
@@ -1,0 +1,57 @@
+name: Daily X Monitor Report
+
+on:
+  schedule:
+    # Run daily at 14:45 UTC.
+    - cron: '45 14 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: krakenwatch-daily-x-monitor
+  cancel-in-progress: false
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    name: Generate daily X report
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate X daily report
+        run: npm run report:x-daily
+        env:
+          X_BEARER_TOKEN: ${{ secrets.X_BEARER_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          X_MONITOR_LLM_MODEL: ${{ secrets.X_MONITOR_LLM_MODEL }}
+
+      - name: Commit and push report
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- reports/x-daily/; then
+            echo "No report changes detected."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add reports/x-daily/
+          git commit -m "chore(report): daily ink 24h snapshot"
+          git push origin HEAD:main

--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ The project can also generate a daily internal snapshot report from a monitored
 X List (with optional account fallback).
 
 - Workflow: `.github/workflows/daily-x-monitor.yml`
-- Name: `Daily Ink X Snapshot`
+- Name: `Daily X Monitor Report`
 - Schedule: daily at `14:45 UTC`
 - Output:
-  - public report: `reports/ink-x-daily/YYYY-MM-DD.md`
-  - internal raw data: `reports/ink-x-daily/raw/YYYY-MM-DD.json`
+  - report: `reports/x-daily/YYYY-MM-DD.md`
+  - internal raw data: `reports/x-daily/raw/YYYY-MM-DD.json`
 
 ### Where to enter your inputs
 
@@ -124,7 +124,7 @@ X List (with optional account fallback).
 2. Add required GitHub repository secrets:
    - `X_BEARER_TOKEN`
    - `OPENAI_API_KEY`
-   - optional: `OPENAI_MODEL`
+   - optional: `X_MONITOR_LLM_MODEL`
    - Note: your X API project must have active API credits/plan access for list
      and timeline endpoints. Without credits, runs fail with `CreditsDepleted`.
 3. (Optional) run locally:

--- a/README.md
+++ b/README.md
@@ -102,3 +102,32 @@ It refreshes `public/site-data.json` from:
 - Hiive, Forge, Nasdaq Private Market, Notice (best-effort secondary price sources)
 
 The workflow commits updated `public/site-data.json` back to `main` when values change.
+
+## Daily Ink 24h X snapshot
+
+The project can also generate a daily internal snapshot report from a monitored
+set of X accounts.
+
+- Workflow: `.github/workflows/daily-x-monitor.yml`
+- Name: `Daily Ink X Snapshot`
+- Schedule: daily at `14:45 UTC`
+- Output:
+  - public report: `reports/ink-x-daily/YYYY-MM-DD.md`
+  - internal raw data: `reports/ink-x-daily/raw/YYYY-MM-DD.json`
+
+### Where to enter your inputs
+
+1. Edit account list + objective in:
+   - `config/x-monitor.config.json`
+2. Add required GitHub repository secrets:
+   - `X_BEARER_TOKEN`
+   - `OPENAI_API_KEY`
+   - optional: `OPENAI_MODEL`
+3. (Optional) run locally:
+   - `npm run snapshot:ink:x`
+
+### Runtime model
+
+This runs in GitHub Actions on a daily schedule (not inside the Cloudflare
+Worker runtime). The Worker and app serve the site; the snapshot job is a
+separate automation pipeline that writes reports to the repo.

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The workflow commits updated `public/site-data.json` back to `main` when values 
 ## Daily Ink 24h X snapshot
 
 The project can also generate a daily internal snapshot report from a monitored
-set of X accounts.
+X List (with optional account fallback).
 
 - Workflow: `.github/workflows/daily-x-monitor.yml`
 - Name: `Daily Ink X Snapshot`
@@ -119,12 +119,16 @@ set of X accounts.
 
 1. Edit account list + objective in:
    - `config/x-monitor.config.json`
+   - Primary mode: set `list_id` (example: `2046327906943500367`)
+   - Optional fallback: `accounts_fallback` usernames
 2. Add required GitHub repository secrets:
    - `X_BEARER_TOKEN`
    - `OPENAI_API_KEY`
    - optional: `OPENAI_MODEL`
+   - Note: your X API project must have active API credits/plan access for list
+     and timeline endpoints. Without credits, runs fail with `CreditsDepleted`.
 3. (Optional) run locally:
-   - `npm run snapshot:ink:x`
+   - `npm run report:x-daily`
 
 ### Runtime model
 

--- a/config/x-monitor.config.json
+++ b/config/x-monitor.config.json
@@ -1,12 +1,8 @@
 {
   "project_name": "Kraken Watch",
   "objective": "Generate a concise 24h snapshot of the most relevant Ink ecosystem developments and what users/builders should watch next.",
-  "accounts": [
-    "inkonchain",
-    "krakenfx",
-    "defillama",
-    "l2beat"
-  ],
+  "list_id": "2046327906943500367",
+  "accounts_fallback": [],
   "x": {
     "base_url": "https://api.twitter.com/2",
     "lookback_hours": 24,
@@ -15,7 +11,8 @@
     "exclude_retweets": true
   },
   "report": {
-    "max_developments": 5,
+    "top_items": 5,
+    "shortlist_size": 20,
     "max_snippet_chars": 220
   },
   "llm": {
@@ -40,5 +37,23 @@
     "governance": 4,
     "security": 8,
     "incident": 8
-  }
+  },
+  "relevance_keywords": [
+    "ink",
+    "ink chain",
+    "kraken",
+    "mainnet",
+    "protocol",
+    "launch",
+    "integration",
+    "bridge",
+    "defi",
+    "tvl",
+    "liquidity",
+    "incentive",
+    "airdrop",
+    "governance",
+    "security",
+    "incident"
+  ]
 }

--- a/config/x-monitor.config.json
+++ b/config/x-monitor.config.json
@@ -1,0 +1,44 @@
+{
+  "project_name": "Kraken Watch",
+  "objective": "Generate a concise 24h snapshot of the most relevant Ink ecosystem developments and what users/builders should watch next.",
+  "accounts": [
+    "inkonchain",
+    "krakenfx",
+    "defillama",
+    "l2beat"
+  ],
+  "x": {
+    "base_url": "https://api.twitter.com/2",
+    "lookback_hours": 24,
+    "max_posts_per_account": 20,
+    "exclude_replies": true,
+    "exclude_retweets": true
+  },
+  "report": {
+    "max_developments": 5,
+    "max_snippet_chars": 220
+  },
+  "llm": {
+    "enabled": true,
+    "model": "gpt-4.1-mini",
+    "temperature": 0.2
+  },
+  "keyword_weights": {
+    "ink": 12,
+    "ink chain": 12,
+    "kraken": 8,
+    "mainnet": 7,
+    "protocol": 6,
+    "launch": 6,
+    "integration": 6,
+    "bridge": 5,
+    "defi": 5,
+    "tvl": 5,
+    "liquidity": 5,
+    "incentive": 4,
+    "airdrop": 4,
+    "governance": 4,
+    "security": 8,
+    "incident": 8
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "refresh:data": "node scripts/refresh-site-data.mjs"
+    "refresh:data": "node scripts/refresh-site-data.mjs",
+    "report:x-daily": "node scripts/generate-x-daily-report.mjs"
   },
   "dependencies": {
     "react": "^19.2.4",

--- a/scripts/generate-x-daily-report.mjs
+++ b/scripts/generate-x-daily-report.mjs
@@ -55,8 +55,15 @@ function escapeRegExp(value) {
 
 async function loadConfig() {
   const parsed = JSON.parse(await readFile(CONFIG_PATH, 'utf8'));
-  if (!Array.isArray(parsed.accounts) || parsed.accounts.length === 0) {
-    throw new Error('config.accounts must contain at least one X username');
+  parsed.x = parsed.x || {};
+  parsed.x.base_url = parsed.x.base_url || 'https://api.twitter.com/2';
+  parsed.x.lookback_hours = Number(parsed.x.lookback_hours ?? 24);
+  parsed.x.max_posts_per_account = Number(parsed.x.max_posts_per_account ?? 20);
+
+  const hasAccounts = Array.isArray(parsed.accounts) && parsed.accounts.length > 0;
+  const hasFallback = Array.isArray(parsed.accounts_fallback) && parsed.accounts_fallback.length > 0;
+  if (!parsed.list_id && !hasAccounts && !hasFallback) {
+    throw new Error('Provide at least one source via list_id, accounts, or accounts_fallback');
   }
   return parsed;
 }
@@ -82,6 +89,32 @@ async function getUserByUsername(username, bearerToken, baseUrl) {
     throw new Error(`No user id found for @${username}`);
   }
   return payload.data;
+}
+
+async function getListMembers(listId, bearerToken, baseUrl, maxMembers = 100) {
+  const members = [];
+  let nextToken = null;
+
+  while (members.length < maxMembers) {
+    const url = new URL(`${baseUrl}/lists/${encodeURIComponent(listId)}/members`);
+    url.searchParams.set('user.fields', 'id,name,username');
+    url.searchParams.set('max_results', String(Math.min(100, maxMembers - members.length)));
+    if (nextToken) {
+      url.searchParams.set('pagination_token', nextToken);
+    }
+
+    const payload = await fetchX(url, bearerToken);
+    if (Array.isArray(payload?.data)) {
+      members.push(...payload.data);
+    }
+
+    nextToken = payload?.meta?.next_token ?? null;
+    if (!nextToken) {
+      break;
+    }
+  }
+
+  return members;
 }
 
 function buildExcludeParam(config) {
@@ -294,7 +327,44 @@ function markdownReport({ runDate, synthesis, shortlist, config, usedFallback })
 async function collectPosts(config, bearerToken) {
   const errors = [];
   const all = [];
-  for (const username of config.accounts) {
+  const accountSet = new Set();
+
+  if (Array.isArray(config.accounts)) {
+    for (const username of config.accounts) {
+      if (username) {
+        accountSet.add(String(username).toLowerCase());
+      }
+    }
+  }
+
+  if (config.list_id) {
+    try {
+      const maxMembers = Number(config.x?.max_list_members ?? 100);
+      const members = await getListMembers(config.list_id, bearerToken, config.x.base_url, maxMembers);
+      for (const member of members) {
+        if (member?.username) {
+          accountSet.add(String(member.username).toLowerCase());
+        }
+      }
+    } catch (error) {
+      errors.push({ account: `list:${config.list_id}`, message: error.message });
+    }
+  }
+
+  if (Array.isArray(config.accounts_fallback)) {
+    for (const username of config.accounts_fallback) {
+      if (username) {
+        accountSet.add(String(username).toLowerCase());
+      }
+    }
+  }
+
+  const resolvedAccounts = [...accountSet];
+  if (!resolvedAccounts.length) {
+    throw new Error(`No monitor accounts resolved. Errors: ${JSON.stringify(errors)}`);
+  }
+
+  for (const username of resolvedAccounts) {
     try {
       const user = await getUserByUsername(username, bearerToken, config.x.base_url);
       const tweets = await getRecentTweets(user.id, bearerToken, config);

--- a/scripts/generate-x-daily-report.mjs
+++ b/scripts/generate-x-daily-report.mjs
@@ -1,0 +1,376 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const CONFIG_PATH = new URL('../config/x-monitor.config.json', import.meta.url);
+const REPORTS_DIR = new URL('../reports/x-daily', import.meta.url);
+const RAW_DIR = new URL('../reports/x-daily/raw', import.meta.url);
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value || !value.trim()) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value.trim();
+}
+
+function maybeEnv(name, fallback = '') {
+  const value = process.env[name];
+  return value && value.trim().length ? value.trim() : fallback;
+}
+
+function toIsoDate(date) {
+  return date.toISOString().slice(0, 10);
+}
+
+function humanDate(date) {
+  return date.toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
+function parseJsonSafe(text, fallback = null) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return fallback;
+  }
+}
+
+function hoursAgo(hours) {
+  const d = new Date();
+  d.setHours(d.getHours() - hours);
+  return d;
+}
+
+function normalizeText(value) {
+  return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+async function loadConfig() {
+  const parsed = JSON.parse(await readFile(CONFIG_PATH, 'utf8'));
+  if (!Array.isArray(parsed.accounts) || parsed.accounts.length === 0) {
+    throw new Error('config.accounts must contain at least one X username');
+  }
+  return parsed;
+}
+
+async function fetchX(url, bearerToken) {
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${bearerToken}`,
+    },
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`X API error ${res.status}: ${body}`);
+  }
+  return res.json();
+}
+
+async function getUserByUsername(username, bearerToken, baseUrl) {
+  const url = new URL(`${baseUrl}/users/by/username/${encodeURIComponent(username)}`);
+  url.searchParams.set('user.fields', 'id,name,username');
+  const payload = await fetchX(url, bearerToken);
+  if (!payload?.data?.id) {
+    throw new Error(`No user id found for @${username}`);
+  }
+  return payload.data;
+}
+
+function buildExcludeParam(config) {
+  const excludes = [];
+  if (config?.x?.exclude_replies !== false) {
+    excludes.push('replies');
+  }
+  if (config?.x?.exclude_retweets !== false) {
+    excludes.push('retweets');
+  }
+  return excludes.join(',');
+}
+
+async function getRecentTweets(userId, bearerToken, config) {
+  const url = new URL(`${config.x.base_url}/users/${userId}/tweets`);
+  url.searchParams.set('max_results', String(Math.min(100, Math.max(5, config.x.max_posts_per_account ?? 12))));
+  const exclude = buildExcludeParam(config);
+  if (exclude) {
+    url.searchParams.set('exclude', exclude);
+  }
+  url.searchParams.set('tweet.fields', 'created_at,public_metrics,lang');
+  const payload = await fetchX(url, bearerToken);
+  return Array.isArray(payload?.data) ? payload.data : [];
+}
+
+function withinLookback(createdAt, lookbackHours) {
+  const dt = new Date(createdAt);
+  if (Number.isNaN(dt.getTime())) {
+    return false;
+  }
+  return dt >= hoursAgo(lookbackHours);
+}
+
+function scoreCategory(text) {
+  const t = text.toLowerCase();
+  if (/(exploit|hack|incident|vulnerability|outage|downtime|drain)/.test(t)) {
+    return 'Risk / Incident';
+  }
+  if (/(launch|live|mainnet|deploy|integration|partnership)/.test(t)) {
+    return 'Launch / Integration';
+  }
+  if (/(tvl|liquidity|volume|inflow|bridge|swap|yield|apy)/.test(t)) {
+    return 'Liquidity / Market';
+  }
+  if (/(grant|builder|dev|tooling|sdk|docs|hackathon)/.test(t)) {
+    return 'Builder / Ecosystem';
+  }
+  return 'General Ecosystem';
+}
+
+function keywordHitCount(text, keywords) {
+  const lc = text.toLowerCase();
+  return keywords.reduce((sum, kw) => {
+    const re = new RegExp(`\\b${escapeRegExp(String(kw).toLowerCase())}\\b`, 'g');
+    const matches = lc.match(re);
+    return sum + (matches ? matches.length : 0);
+  }, 0);
+}
+
+function engagementScore(metrics = {}) {
+  const likes = Number(metrics.like_count ?? 0);
+  const reposts = Number(metrics.retweet_count ?? 0);
+  const replies = Number(metrics.reply_count ?? 0);
+  const quotes = Number(metrics.quote_count ?? 0);
+  return likes + reposts * 2 + replies * 2 + quotes * 1.5;
+}
+
+function buildDeterministicRanking(posts, config) {
+  const keywords = Array.isArray(config.relevance_keywords) ? config.relevance_keywords : [];
+  const ranked = posts.map((post) => {
+    const text = normalizeText(post.text);
+    const keyHits = keywordHitCount(text, keywords);
+    const ageHours = Math.max(0, (Date.now() - new Date(post.created_at).getTime()) / 3_600_000);
+    const recencyBonus = Math.max(0, 24 - ageHours) * 1.2;
+    const engage = engagementScore(post.public_metrics);
+    const score = keyHits * 8 + recencyBonus + Math.min(35, Math.log10(engage + 1) * 12);
+    return {
+      ...post,
+      _rank_score: Math.round(score * 10) / 10,
+      _keyword_hits: keyHits,
+      _engagement: Math.round(engage * 10) / 10,
+      _category: scoreCategory(text),
+    };
+  });
+  ranked.sort((a, b) => b._rank_score - a._rank_score);
+  return ranked;
+}
+
+function buildLlmPrompt(shortlist, config) {
+  const lines = shortlist.map((post, i) => [
+    `Item ${i + 1}`,
+    `id: ${post.id}`,
+    `created_at: ${post.created_at}`,
+    `rank_score: ${post._rank_score}`,
+    `engagement: ${post._engagement}`,
+    `category_guess: ${post._category}`,
+    `text: ${normalizeText(post.text)}`,
+    '',
+  ].join('\n'));
+
+  return [
+    `Objective: ${config.objective}`,
+    'You are generating an internal Ink ecosystem snapshot from past-24h X posts.',
+    'Do not include source account names. Focus on ecosystem developments only.',
+    'Return strict JSON with schema:',
+    '{"summary":"string","items":[{"id":"string","headline":"string","why_it_matters":"string","category":"string","watch_next":"string","priority":1-5}],"watchlist":"string"}',
+    'Be concise and factual. No markdown.',
+    '',
+    ...lines,
+  ].join('\n');
+}
+
+async function runLlm(shortlist, config) {
+  const apiKey = requireEnv('OPENAI_API_KEY');
+  const model = maybeEnv('OPENAI_MODEL', config.llm?.model || 'gpt-4.1-mini');
+  const prompt = buildLlmPrompt(shortlist, config);
+
+  const res = await fetch('https://api.openai.com/v1/responses', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model,
+      input: [
+        {
+          role: 'system',
+          content:
+            'You are an ecosystem intelligence analyst. Produce concise, structured synthesis with no source attribution.',
+        },
+        { role: 'user', content: prompt },
+      ],
+      temperature: Number(config.llm?.temperature ?? 0.2),
+      max_output_tokens: 1600,
+    }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`OpenAI error ${res.status}: ${await res.text()}`);
+  }
+
+  const payload = await res.json();
+  const parsed = parseJsonSafe(payload?.output_text, null);
+  if (!parsed || !Array.isArray(parsed.items)) {
+    throw new Error(`Unexpected LLM response: ${payload?.output_text ?? 'empty'}`);
+  }
+  return parsed;
+}
+
+function fallbackSynthesis(shortlist) {
+  return {
+    summary:
+      'Automated deterministic snapshot generated without LLM synthesis. Prioritized by relevance keywords, recency, and engagement.',
+    items: shortlist.slice(0, 5).map((post, idx) => ({
+      id: post.id,
+      headline: `Ecosystem signal #${idx + 1}`,
+      why_it_matters: `Ranked high on relevance (${post._rank_score}) in ${post._category}.`,
+      category: post._category,
+      watch_next: 'Track follow-on announcements and onchain traction in the next 24h.',
+      priority: Math.max(1, 5 - idx),
+    })),
+    watchlist: 'LLM unavailable; verify top signals manually.',
+  };
+}
+
+function markdownReport({ runDate, synthesis, shortlist, config, usedFallback }) {
+  const iso = toIsoDate(runDate);
+  const lines = [
+    `# Ink 24h Snapshot — ${humanDate(runDate)}`,
+    '',
+    `- Window: last ${config.x.lookback_hours} hours`,
+    `- Posts analyzed: ${shortlist.length}`,
+    `- Method: ${usedFallback ? 'rules-only fallback' : 'rules + LLM synthesis'}`,
+    '',
+    '## Daily Summary',
+    '',
+    synthesis.summary || 'No summary generated.',
+    '',
+    '## Top Ecosystem Developments',
+    '',
+  ];
+
+  (synthesis.items || []).slice(0, config.report.top_items).forEach((item, idx) => {
+    lines.push(
+      `### ${idx + 1}) ${item.headline || `Development ${idx + 1}`}`,
+      '',
+      `- Category: ${item.category || 'General Ecosystem'}`,
+      `- Why it matters: ${item.why_it_matters || 'n/a'}`,
+      `- Watch next (24h): ${item.watch_next || 'n/a'}`,
+      `- Priority: ${item.priority ?? 'n/a'}/5`,
+      '',
+    );
+  });
+
+  lines.push(
+    '## Watchlist',
+    '',
+    synthesis.watchlist || 'No watchlist generated.',
+    '',
+    '## Run Metadata',
+    '',
+    `- report_id: ink-24h-${iso}`,
+    `- generated_at_utc: ${runDate.toISOString()}`,
+    `- attribution_mode: internal-only (no public account listing)`,
+  );
+  return `${lines.join('\n')}\n`;
+}
+
+async function collectPosts(config, bearerToken) {
+  const errors = [];
+  const all = [];
+  for (const username of config.accounts) {
+    try {
+      const user = await getUserByUsername(username, bearerToken, config.x.base_url);
+      const tweets = await getRecentTweets(user.id, bearerToken, config);
+      for (const tweet of tweets) {
+        if (!withinLookback(tweet.created_at, config.x.lookback_hours)) {
+          continue;
+        }
+        all.push({
+          ...tweet,
+          _source_username: user.username,
+          url: `https://x.com/${user.username}/status/${tweet.id}`,
+        });
+      }
+    } catch (error) {
+      errors.push({ account: username, message: error.message });
+    }
+  }
+  return { posts: all, errors };
+}
+
+async function main() {
+  const config = await loadConfig();
+  const runDate = new Date();
+  const iso = toIsoDate(runDate);
+  const bearerToken = requireEnv('X_BEARER_TOKEN');
+
+  const { posts, errors } = await collectPosts(config, bearerToken);
+  if (posts.length === 0) {
+    throw new Error(`No posts collected. Errors: ${JSON.stringify(errors)}`);
+  }
+
+  const ranked = buildDeterministicRanking(posts, config);
+  const shortlistSize = Number(config.report.shortlist_size ?? 20);
+  const shortlist = ranked.slice(0, shortlistSize);
+
+  let synthesis = null;
+  let usedFallback = false;
+  try {
+    synthesis = await runLlm(shortlist, config);
+  } catch (error) {
+    errors.push({ account: 'llm', message: error.message });
+    synthesis = fallbackSynthesis(shortlist);
+    usedFallback = true;
+  }
+
+  await mkdir(REPORTS_DIR, { recursive: true });
+  await mkdir(RAW_DIR, { recursive: true });
+
+  const mdPath = new URL(`./${iso}.md`, REPORTS_DIR);
+  const rawPath = new URL(`./${iso}.json`, RAW_DIR);
+
+  const markdown = markdownReport({
+    runDate,
+    synthesis,
+    shortlist,
+    config,
+    usedFallback,
+  });
+
+  const raw = {
+    generated_at: runDate.toISOString(),
+    config_snapshot: config,
+    used_fallback: usedFallback,
+    errors,
+    shortlist,
+    synthesis,
+  };
+
+  await writeFile(mdPath, markdown, 'utf8');
+  await writeFile(rawPath, `${JSON.stringify(raw, null, 2)}\n`, 'utf8');
+
+  console.log(`Generated report: ${path.relative(process.cwd(), mdPath.pathname)}`);
+  console.log(`Generated raw data: ${path.relative(process.cwd(), rawPath.pathname)}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a daily GitHub Actions workflow (`Daily X Monitor Report`) that runs at 14:45 UTC and can be manually triggered
- add `scripts/generate-x-daily-report.mjs` to fetch monitored X content, score relevance for Ink ecosystem signal, and produce a concise daily snapshot
- add `config/x-monitor.config.json` for objective, list/account sources, lookback, and report settings
- generate two outputs per run:
  - `reports/x-daily/YYYY-MM-DD.md` (daily snapshot)
  - `reports/x-daily/raw/YYYY-MM-DD.json` (internal source/audit dataset)
- intentionally avoid source account attribution in markdown output to match product direction

## Source ingestion behavior
- primary mode: pull account set from X List (`list_id`)
- fallback mode: use `accounts_fallback` usernames when needed
- resilient source resolution across list + fallback with deduplication

## Inputs and operation
- edit source and objective settings in `config/x-monitor.config.json`:
  - `list_id` (currently set to `2046327906943500367`)
  - optional `accounts_fallback`
- add required repo secrets:
  - `X_BEARER_TOKEN`
  - `OPENAI_API_KEY`
  - optional `X_MONITOR_LLM_MODEL`
- local/manual execution command:
  - `npm run report:x-daily`

## Validation
- `node --check scripts/generate-x-daily-report.mjs`
- `npm run lint`
- `npm run build`

## Note on X API access
- list-mode execution may fail with `CreditsDepleted` (HTTP 402) when X API project credits/plan access are insufficient for list + timeline endpoints.
- pipeline is code-complete and will run once the X API project has active access.

## Branch refresh
- rebased/merged onto latest `main` so this PR includes current production fixes and docs alignment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a179696-b4c7-4a30-b488-3ac5e9b47493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a179696-b4c7-4a30-b488-3ac5e9b47493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

