### PR TITLE
Fix Notice Kraken price scraping and refresh live data

### DIFF
--- a/public/site-data.json
+++ b/public/site-data.json
@@ -1,5 +1,5 @@
 {
-  "updated_at": "2026-04-20T20:53:08.486Z",
+  "updated_at": "2026-04-20T21:00:00.634Z",
   "updated_display": "April 20, 2026",
   "ink": {
     "tvl_millions": 318.3,
@@ -14,8 +14,8 @@
     "hiive_pps": 33.33,
     "forge_pps": 34.09,
     "npm_pps": 37.69,
-    "notice_pps": 31.36,
-    "avg_pps": 33.57,
+    "notice_pps": 48.87,
+    "avg_pps": 33.87,
     "volume_30d_est_m": 13.5,
     "volume_note": "Est. 30D vol. across all venues · based on Hiive H50 activity",
     "updated": "April 20, 2026"

--- a/scripts/refresh-site-data.mjs
+++ b/scripts/refresh-site-data.mjs
@@ -324,6 +324,23 @@ async function getForgePriceAndDate() {
 }
 
 async function getNoticePrice() {
+  const extractFromMirror = async () => {
+    const mirrorText = await withRetries(
+      'Notice mirror page',
+      () => fetchText('https://r.jina.ai/http://notice.co/c/kraken'),
+      2,
+    );
+
+    // Mirror tends to expose an explicit headline like:
+    // "Kraken Stock $49.06 | ..."
+    const mirrorMatch = mirrorText.match(/Kraken Stock\s*\$([0-9]+(?:\.[0-9]{1,2})?)/i);
+    if (mirrorMatch) {
+      return parseNumeric(mirrorMatch[1]);
+    }
+
+    return extractFirstCurrency(mirrorText, /Kraken[\s\S]{0,1200}/i);
+  };
+
   try {
     const html = await withRetries(
       'Notice page',
@@ -333,7 +350,16 @@ async function getNoticePrice() {
         }),
       2,
     );
-    return extractFirstCurrency(html, /Kraken[\s\S]{0,1200}/i);
+    const directValue = extractFirstCurrency(html, /Kraken[\s\S]{0,1200}/i);
+    if (directValue != null) {
+      return directValue;
+    }
+  } catch {
+    // Fall through to mirror source when Notice blocks bot traffic.
+  }
+
+  try {
+    return await extractFromMirror();
   } catch {
     return null;
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update `getNoticePrice()` in `scripts/refresh-site-data.mjs` to handle Notice bot-blocking by falling back to a resilient mirror source (`r.jina.ai/http://notice.co/c/kraken`)
- when using the mirror source, parse the explicit `Kraken Stock $...` headline first for better accuracy
- refresh `public/site-data.json` with corrected Notice-derived price

## Root cause
Notice frequently returns 403 to bot-like requests. The prior logic would then keep the stale previous `notice_pps` value (31.36), which made our displayed secondary pricing lag behind current Notice pricing.

## Result after refresh
- `notice_pps`: `48.87`
- `avg_pps`: `33.87`

## Validation
- `npm run refresh:data`
- `npm run lint`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

