### PR TITLE
Raise secondary price outlier threshold to 0.5

### DIFF
--- a/public/site-data.json
+++ b/public/site-data.json
@@ -1,5 +1,5 @@
 {
-  "updated_at": "2026-04-20T21:00:00.634Z",
+  "updated_at": "2026-04-20T21:10:36.159Z",
   "updated_display": "April 20, 2026",
   "ink": {
     "tvl_millions": 318.3,
@@ -15,7 +15,7 @@
     "forge_pps": 34.09,
     "npm_pps": 37.69,
     "notice_pps": 48.87,
-    "avg_pps": 33.87,
+    "avg_pps": 35.66,
     "volume_30d_est_m": 13.5,
     "volume_note": "Est. 30D vol. across all venues · based on Hiive H50 activity",
     "updated": "April 20, 2026"

--- a/scripts/refresh-site-data.mjs
+++ b/scripts/refresh-site-data.mjs
@@ -10,7 +10,7 @@ const SECONDARY_BASE_WEIGHTS = {
   notice_pps: 0.1,
 };
 
-const MAX_OUTLIER_DEVIATION = 0.3;
+const MAX_OUTLIER_DEVIATION = 0.5;
 
 function parseNumeric(input) {
   if (input == null) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- increase `MAX_OUTLIER_DEVIATION` in `scripts/refresh-site-data.mjs` from `0.3` to `0.5`
- refresh `public/site-data.json` using the updated threshold

## Effect
With current venue inputs, Notice (`48.87`) is no longer excluded from `avg_pps`.

Updated secondary values on this branch:
- `hiive_pps`: `33.33`
- `forge_pps`: `34.09`
- `npm_pps`: `37.69`
- `notice_pps`: `48.87`
- `avg_pps`: `35.66`

## Validation
- `npm run refresh:data`
- `npm run lint`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61ef090f-6209-4c4d-b698-47b119e40d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

